### PR TITLE
Implement test harness for editing commands

### DIFF
--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -1,14 +1,14 @@
-import { TextDocument, Selection, TextEditor } from "vscode"
+import { TextDocument, Selection, TextEditor, TextEditorEdit } from "vscode"
 import Parser from "web-tree-sitter"
 
-export type CommandRet = Promise<Selection | undefined>
+interface CommandRetInner {
+  selection?: Selection
+  edit?: (editBuilder: TextEditorEdit) => void
+}
 
-export type Command = (
-  editor: TextEditor,
-  doc: TextDocument,
-  selection: Selection,
-  tree: Parser.Tree,
-) => CommandRet
+export type CommandRet = CommandRetInner | undefined
+
+export type Command = (doc: TextDocument, selection: Selection, tree: Parser.Tree) => CommandRet
 
 class SelectionStackByDoc {
   private state = new Map<TextDocument, Selection[]>()

--- a/src/commands/edit.test.ts
+++ b/src/commands/edit.test.ts
@@ -8,6 +8,30 @@ const cases: TUtils.EditTest[] = [
     initialText: "[1,2,3,[👉🏻4👈🏻,5]]",
     finalText: "[1,2,3,4]",
   },
+  {
+    languageId: "typescript",
+    cmd: Cmds.SwapForward,
+    initialText: "[1,👉🏻2👈🏻,3]",
+    finalText: "[1,3,2]",
+  },
+  {
+    languageId: "typescript",
+    cmd: Cmds.SwapBackward,
+    initialText: "[1,👉🏻2👈🏻,3]",
+    finalText: "[2,1,3]",
+  },
+  {
+    languageId: "typescript",
+    cmd: Cmds.SlurpForward,
+    initialText: "[[1,2👉🏻👈🏻,3],4,5]",
+    finalText: "[[1,2,3,4],5]",
+  },
+  {
+    languageId: "typescript",
+    cmd: Cmds.BarfForward,
+    initialText: "[[1,2👉🏻👈🏻,3],4,5]",
+    finalText: "[[1,2,],3,4,5]",
+  },
 ]
 
 describe("Edit Commands", () => {

--- a/src/commands/edit.test.ts
+++ b/src/commands/edit.test.ts
@@ -1,0 +1,15 @@
+import * as Cmds from "./edit"
+import * as TUtils from "../utils/test"
+
+const cases: TUtils.EditTest[] = [
+  {
+    languageId: "typescript",
+    cmd: Cmds.Raise,
+    initialText: "[1,2,3,[👉🏻4👈🏻,5]]",
+    finalText: "[1,2,3,4]",
+  },
+]
+
+describe("Edit Commands", () => {
+  test.concurrent.each(cases)("%#", TUtils.executeEditTest)
+})

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -125,6 +125,7 @@ export const BarfForward = (doc: TextDocument, sel: Selection, tree: Parser.Tree
   const insertionPoint = tsUtils.SyntaxNode2Selection(nextSibling).start
 
   const edit = (editBuilder: TextEditorEdit) => {
+    editBuilder.insert(insertionPoint, lastNamedChild.text + separator)
     editBuilder.replace(
       new Selection(
         tsUtils.SyntaxNode2Selection(lastNamedChild).start,
@@ -132,7 +133,6 @@ export const BarfForward = (doc: TextDocument, sel: Selection, tree: Parser.Tree
       ),
       "",
     )
-    editBuilder.insert(insertionPoint, lastNamedChild.text + separator)
   }
 
   return { edit }

--- a/src/commands/selection.ts
+++ b/src/commands/selection.ts
@@ -4,8 +4,7 @@ import * as vsUtils from "../utils/vscode"
 import * as tsUtils from "../utils/tree_sitter"
 import { CommandRet, globalSelectionStack } from "./common"
 
-export const ExpandSelection = async (
-  _: TextEditor,
+export const ExpandSelection = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -37,20 +36,18 @@ export const ExpandSelection = async (
 
   globalSelectionStack.push(doc, sel)
 
-  return tsUtils.SyntaxNode2Selection(parent)
+  return { selection: tsUtils.SyntaxNode2Selection(parent) }
 }
 
-export const ContractSelection = async (
-  _: TextEditor,
+export const ContractSelection = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
 ): CommandRet => {
-  return globalSelectionStack.pop(doc)
+  return { selection: globalSelectionStack.pop(doc) }
 }
 
-export const SelectTopLevel = async (
-  _: TextEditor,
+export const SelectTopLevel = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -68,7 +65,7 @@ export const SelectTopLevel = async (
     node = node.parent
   }
 
-  return tsUtils.SyntaxNode2Selection(node)
+  return { selection: tsUtils.SyntaxNode2Selection(node) }
 }
 
 const growFromLeft = (sel: Selection, node: SyntaxNode) => {
@@ -104,7 +101,7 @@ const GrowShrink = (
   tree: Parser.Tree,
   side: "start" | "end" | "active" | "anchor",
   direction: "left" | "right",
-): Selection | undefined => {
+): CommandRet => {
   if (sel.isEmpty) {
     const node = tsUtils.SmallestNodeEnclosingSel(
       tree.rootNode,
@@ -115,9 +112,14 @@ const GrowShrink = (
     }
 
     if (direction === "right" && node) {
-      return tsUtils.SyntaxNode2Selection(node)
+      return { selection: tsUtils.SyntaxNode2Selection(node) }
     } else if (direction === "left" && node.previousNamedSibling) {
-      return new Selection(sel.end, tsUtils.SyntaxNode2Selection(node.previousNamedSibling).start)
+      return {
+        selection: new Selection(
+          sel.end,
+          tsUtils.SyntaxNode2Selection(node.previousNamedSibling).start,
+        ),
+      }
     }
   }
 
@@ -197,11 +199,10 @@ const GrowShrink = (
   if (!newSel) {
     return
   }
-  return sel.isReversed ? vsUtils.reverse(newSel) : newSel
+  return { selection: sel.isReversed ? vsUtils.reverse(newSel) : newSel }
 }
 
-export const GrowSelectionAtEnd = async (
-  _: TextEditor,
+export const GrowSelectionAtEnd = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -209,8 +210,7 @@ export const GrowSelectionAtEnd = async (
   return GrowShrink(doc, sel, tree, "end", "right")
 }
 
-export const ShrinkSelectionAtEnd = async (
-  _: TextEditor,
+export const ShrinkSelectionAtEnd = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -218,8 +218,7 @@ export const ShrinkSelectionAtEnd = async (
   return GrowShrink(doc, sel, tree, "end", "left")
 }
 
-export const GrowSelectionAtStart = async (
-  _: TextEditor,
+export const GrowSelectionAtStart = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -227,8 +226,7 @@ export const GrowSelectionAtStart = async (
   return GrowShrink(doc, sel, tree, "start", "left")
 }
 
-export const ShrinkSelectionAtStart = async (
-  _: TextEditor,
+export const ShrinkSelectionAtStart = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -236,17 +234,11 @@ export const ShrinkSelectionAtStart = async (
   return GrowShrink(doc, sel, tree, "start", "right")
 }
 
-export const SelectForward = async (
-  _: TextEditor,
-  doc: TextDocument,
-  sel: Selection,
-  tree: Parser.Tree,
-): CommandRet => {
+export const SelectForward = (doc: TextDocument, sel: Selection, tree: Parser.Tree): CommandRet => {
   return GrowShrink(doc, sel, tree, "active", "right")
 }
 
-export const SelectBackward = async (
-  _: TextEditor,
+export const SelectBackward = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -254,8 +246,7 @@ export const SelectBackward = async (
   return GrowShrink(doc, sel, tree, "active", "left")
 }
 
-export const MoveCursorForward = async (
-  _: TextEditor,
+export const MoveCursorForward = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -271,11 +262,10 @@ export const MoveCursorForward = async (
   if (!sibling) {
     return
   }
-  return vsUtils.emptySelection(tsUtils.SyntaxNode2Selection(sibling).start)
+  return { selection: vsUtils.emptySelection(tsUtils.SyntaxNode2Selection(sibling).start) }
 }
 
-export const MoveCursorBackward = async (
-  _: TextEditor,
+export const MoveCursorBackward = (
   doc: TextDocument,
   sel: Selection,
   tree: Parser.Tree,
@@ -290,5 +280,5 @@ export const MoveCursorBackward = async (
   if (!sibling) {
     return
   }
-  return vsUtils.emptySelection(tsUtils.SyntaxNode2Selection(sibling).start)
+  return { selection: vsUtils.emptySelection(tsUtils.SyntaxNode2Selection(sibling).start) }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,13 +31,15 @@ const initCommands = (
 
         const ASTtree = parser.parse(doc.getText())
 
-        const newSel = await cmd[1](editor, doc, selection, ASTtree)
+        const ret = cmd[1](doc, selection, ASTtree)
 
-        if (!newSel) {
-          return
+        if (ret?.edit) {
+          editor.edit(ret.edit)
         }
 
-        vscode.window.activeTextEditor.selection = newSel
+        if (ret?.selection) {
+          vscode.window.activeTextEditor.selection = ret.selection
+        }
       }),
     )
   }

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -98,25 +98,25 @@ export const executeSelectionChangeTest = async (testCase: SelectionChangeTest) 
   }
 
   const parser = await loadParser(doc)
-  const newSel = await testCase.cmd(editor, doc, initialSel, parser.parse(doc.getText()))
+  const ret = await testCase.cmd(doc, initialSel, parser.parse(doc.getText()))
 
-  if (newSel && !finalSel.isEqual(newSel)) {
+  if (ret?.selection && !finalSel.isEqual(ret.selection)) {
     console.log(
       "Want",
       testCase.text,
       "\n----------------\n",
       "Have",
       [
-        doc.getText().slice(0, doc.offsetAt(newSel.start)),
+        doc.getText().slice(0, doc.offsetAt(ret.selection.start)),
         FSS,
-        doc.getText().slice(doc.offsetAt(newSel.start), doc.offsetAt(newSel.end)),
+        doc.getText().slice(doc.offsetAt(ret.selection.start), doc.offsetAt(ret.selection.end)),
         FSE,
-        doc.getText().slice(doc.offsetAt(newSel.start)),
+        doc.getText().slice(doc.offsetAt(ret.selection.start)),
       ].join(""),
     )
   }
 
-  expect(newSel).toEqual(finalSel)
+  expect(ret?.selection).toEqual(finalSel)
 }
 
 export interface EditTest {
@@ -141,7 +141,7 @@ export const executeEditTest = async (testCase: EditTest) => {
   }
 
   const parser = await loadParser(doc)
-  await testCase.cmd(editor, doc, initialSel, parser.parse(doc.getText()))
+  await testCase.cmd(doc, initialSel, parser.parse(doc.getText()))
 
   expect(editor.document.getText()).toEqual(testCase.finalText)
 }

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -118,3 +118,30 @@ export const executeSelectionChangeTest = async (testCase: SelectionChangeTest) 
 
   expect(newSel).toEqual(finalSel)
 }
+
+export interface EditTest {
+  initialText: string
+  finalText: string
+  languageId: string
+  cmd: Command
+}
+
+export const executeEditTest = async (testCase: EditTest) => {
+  const { editor, doc, initialSel, finalSel } = text2VScodeObjs(
+    testCase.languageId,
+    testCase.initialText,
+  )
+
+  if (!initialSel) {
+    throw new Error("Could not find Initial Selection")
+  }
+
+  if (finalSel) {
+    throw new Error("Should not have Final Selection")
+  }
+
+  const parser = await loadParser(doc)
+  await testCase.cmd(editor, doc, initialSel, parser.parse(doc.getText()))
+
+  expect(editor.document.getText()).toEqual(testCase.finalText)
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,3 +19,6 @@ export function find<T, R>(array: T[], fn: (i: T) => R | undefined): [T, R] | []
   }
   return []
 }
+
+export const replaceStr = (base: string, from: number, to: number, toInsert: string): string =>
+  base.slice(0, from) + toInsert + base.slice(to)

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -74,3 +74,14 @@ export const moveSelectionToFirstNonWhitespace = (
     }
   }
 }
+
+/**
+ * Convert a Position, a range or a Selection into a Selection
+ */
+export const selectionify = (location: Position | Range | Selection): Selection => {
+  if ((location as any).line) {
+    return new Selection(location as any, location as any)
+  } else {
+    return new Selection((location as any).start, (location as any).end)
+  }
+}

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -79,7 +79,7 @@ export const moveSelectionToFirstNonWhitespace = (
  * Convert a Position, a range or a Selection into a Selection
  */
 export const selectionify = (location: Position | Range | Selection): Selection => {
-  if ((location as any).line) {
+  if ((location as any).line !== undefined) {
     return new Selection(location as any, location as any)
   } else {
     return new Selection((location as any).start, (location as any).end)


### PR DESCRIPTION
Status: edits are not recognized.

Calling `editor.document.getText()` after the invocation of an edit command returns the text unchanged.